### PR TITLE
Slight tweak to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ relevant *.ttf files that end users need to use the fonts.
 ## About 
 
 Created for easier access to all of Google's Web Fonts, with a smaller download
-size (~60 MB) compared with using Google's official repository (~2 GB).
+size (~200 MB) compared with using Google's official repository (~2 GB).
 
 ### Installation
 


### PR DESCRIPTION
Thanks a million for providing this resource, by the way!!! I tried to pull all the fonts with Mercurial, but it kept failing (slightly unstable Internet connection)... this is so much more convenient!

I noticed that the README said this repo is ~60MB, but `du` tells me that my freshly cloned repo takes 244MB on disk. Perhaps the number of fonts has grown a lot over time? Anyways, I just tweaked the README slightly to make it more accurate.
